### PR TITLE
Add .tye/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+.tye/
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
That folder seems to be used by tye when it's running to track PID